### PR TITLE
Use currentValue instead of value in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here's how the native JavaScript control is rendered in my plug-in:
         return (
             <input id="mySlider"
                 type="range"
-                value={this.props.value}
+                currentValue={this.props.value}
                 min={this.props.min}
                 max={this.props.max}
                 onInput={this.props.handleChange}


### PR DESCRIPTION
If you use `value` as a prop, React won't allow you to change value. Use `currentValue` instead.